### PR TITLE
honor -c, --color, and --colors

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -21,10 +21,10 @@ var minimist = require('minimist');
 var spawn = require('child_process').spawn;
 
 var argv = minimist(process.argv.slice(2), {
-    boolean: [ 'c', 'h', 'q', 'json' ],
-    alias: { c: 'color', color: 'colors', h: 'help', q: 'quiet' }
+    boolean: [ 'c', 'color', 'colors', 'h', 'q', 'json' ],
+    alias: { c: ['color', 'colors'], h: 'help', q: 'quiet' },
+    default: { c: process.stdout.isTTY, color: process.stdout.isTTY, colors: process.stdout.isTTY }
 });
-var vargv = minimist(process.argv.slice(2));
 
 var args = argv._.slice();
 if (args.length === 0 || argv.h || argv.help) {
@@ -50,9 +50,7 @@ node.on('exit', onexit('node'));
 var cargs = [];
 if (argv.json) cargs.push('--json');
 if (argv.quiet) cargs.push('--quiet');
-if (vargv.color === undefined && process.stdout.isTTY) {
-    cargs.push('--color');
-}
+if (argv.color) cargs.push('--color');
 
 var coverifyExecutable = process.platform === 'win32' ? 'coverify.cmd' : 'coverify';
 var coverify = spawn(coverifyExecutable, cargs);

--- a/readme.markdown
+++ b/readme.markdown
@@ -79,7 +79,7 @@ usage: covert {OPTIONS} FILES
 
       Only print coverage data, suppressing all other output.
 
-    -c, --color
+    -c, --color, --colors
 
       Use color in the output. Default: true if stdout is a TTY.
 


### PR DESCRIPTION
Previously,
argv.c and argv.color could end up with different values
--color test/test.js set argv.color to test/test.js rather than putting test/test.js in argv._
default behavior for color parsed options differently and failed to place --color in cargs when specifically requested